### PR TITLE
Fixes error when CoreMolecule specifies no atoms to delete

### DIFF
--- a/molfunc/molecules.py
+++ b/molfunc/molecules.py
@@ -134,11 +134,9 @@ class CoreMolecule(Molecule):
     def _check_datom_idxs(self):
         """Ensure that all the atoms that will be replaced by fragments are monovalent"""
 
-        # self.datom_idxs is None when constructor has atoms_to_del=None
-        if self.datom_idxs is not None:
-            for i in self.datom_idxs:
-                if self.atoms[i].valence > 1:
-                    exit(f'Cannot modify atom {self.atoms[i].label} with valency {self.atoms[i].valence }')
+        for i in self.datom_idxs:
+            if self.atoms[i].valence > 1:
+                exit(f'Cannot modify atom {self.atoms[i].label} with valency {self.atoms[i].valence }')
 
         return None
 
@@ -169,7 +167,7 @@ class CoreMolecule(Molecule):
         super(CoreMolecule, self).__init__(name=name, xyz_filename=xyz_filename, smiles=smiles)
 
         # Atom indexes to delete are the atoms minus one as atoms_to_del should not have 0 in the list
-        self.datom_idxs = [i - 1 for i in atoms_to_del] if atoms_to_del is not None else None
+        self.datom_idxs = [i - 1 for i in atoms_to_del] if atoms_to_del is not None else []
         self._check_datom_idxs()
 
         # Nearest neighbour atoms to those deleted to enable translation of the fragment

--- a/molfunc/molecules.py
+++ b/molfunc/molecules.py
@@ -134,9 +134,11 @@ class CoreMolecule(Molecule):
     def _check_datom_idxs(self):
         """Ensure that all the atoms that will be replaced by fragments are monovalent"""
 
-        for i in self.datom_idxs:
-            if self.atoms[i].valence > 1:
-                exit(f'Cannot modify atom {self.atoms[i].label} with valency {self.atoms[i].valence }')
+        # self.datom_idxs is None when constructor has atoms_to_del=None
+        if self.datom_idxs is not None:
+            for i in self.datom_idxs:
+                if self.atoms[i].valence > 1:
+                    exit(f'Cannot modify atom {self.atoms[i].label} with valency {self.atoms[i].valence }')
 
         return None
 


### PR DESCRIPTION
When CoreMolecule() is called with `atoms_to_del` left to be the default `None` option, the function `self._check_datom_idxs()` raises a `TypeError`.

Here is sample code to reproduce the error:
```python
from molfunc import CoreMolecule, CombinedMolecule

smiles = "C1=CC=CC=C1"
template = CoreMolecule(smiles=smiles)
```

Here is the pseudo error stack:
```python
----> 4 template = CoreMolecule(smiles=smiles)
~/.conda/envs/flpipe/lib/python3.7/site-packages/molfunc-1.0.0-py3.7.egg/molfunc/molecules.py in __init__(self, name, xyz_filename, smiles, atoms_to_del)
--> 171         self._check_datom_idxs()
~/.conda/envs/flpipe/lib/python3.7/site-packages/molfunc-1.0.0-py3.7.egg/molfunc/molecules.py in _check_datom_idxs(self)
--> 137         for i in self.datom_idxs:
TypeError: 'NoneType' object is not iterable
```

Edit: I changed the way I fixed the issue through consideration of this line in the `CombinedMolecule()` constructor:

```python
self.n_fragments_to_add = len(self.core_mol.datom_idxs)
```