### PR TITLE
Fixes issue with removing first atom

### DIFF
--- a/molfunc/molecules.py
+++ b/molfunc/molecules.py
@@ -146,7 +146,7 @@ class CoreMolecule(Molecule):
 
         for i in self.datom_idxs:
 
-            if not 0 < i < self.n_atoms:
+            if not 0 <= i < self.n_atoms:
                 raise DatomsNotValid(f'Can\'t functionalise an atom {i} - not '
                                      f'in the list of atoms')
 


### PR DESCRIPTION
## Issue:
When creating a `CoreMolecule()`, the argument `atoms_to_del` currently cannot accept any list including the index `[1]`. Therefore, the first atom in a system cannot be removed.

## Code to reproduce:
```
core = CoreMolecule(xyz_filename=generic.xyz, atoms_to_del=[1])
```

## Error stack:

```
in /molfunc/molecules.py
    149             if not 0 < i < self.n_atoms:
--> 150                 raise DatomsNotValid(f'Can\'t functionalise an atom {i} - not '
    151                                      f'in the list of atoms')
    152 

DatomsNotValid: Can't functionalise an atom 0 - not in the list of atoms
```

The error has to do with the fact that the input `atoms_to_del` starts at index 1, then all of the indices are subtracted by one, and then this check is performed.