### PR TITLE
Add all fragment combinations

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ use cases include catalyst functionalisation, ligand modification and combinator
 
 ## Installation
 ```
-pip install molfunc==2.0.0a0
+pip install molfunc==2.0.0b0
 ```
 The old Python/Cython [version](https://github.com/duartegroup/molfunc/tree/v1) is still available with `pip install molfunc=1.0.0`. Alternatively, to install from source:
 ```
@@ -45,7 +45,11 @@ molfunc examples/PH3.xyz -a 2 3 4 -f Me
 ```
 
 where in both cases all hydrogen atoms (atom indexes 2, 3, 4) are swapped for methyls. See *examples/* 
-for more examples.
+for more examples. Functionalising with all combinations of fragments is also possible with
+
+```
+molfunc examples/PH3.xyz -a 2 --all
+```
 
 
 ## Citation

--- a/molfunc/__init__.py
+++ b/molfunc/__init__.py
@@ -1,5 +1,6 @@
-from molfunc.molecules import print_combined_molecule
+from molfunc.molecules import print_combined_molecule, print_all_combined_molecules
 from molfunc.fragments import names as fragment_names
 
 __all__ = ['print_combined_molecule',
+           'print_all_combined_molecules',
            'fragment_names']

--- a/molfunc/include/species/combined.h
+++ b/molfunc/include/species/combined.h
@@ -7,7 +7,6 @@
 #include "string"
 
 
-
 namespace molfunc{
 
     void print_all_combined_molecules(const string& xyz_filename,

--- a/molfunc/include/species/combined.h
+++ b/molfunc/include/species/combined.h
@@ -10,6 +10,10 @@
 
 namespace molfunc{
 
+    void print_all_combined_molecules(const string& xyz_filename,
+                                      const string& core_xyz_filename,
+                                      const vector<unsigned int>& atom_idxs_to_del);
+
     void print_combined_molecule_from_names(const string& xyz_filename,
                                             const string& core_xyz_filename,
                                             const vector<unsigned int>& atom_idxs_to_del,

--- a/molfunc/include/species/fragments.h
+++ b/molfunc/include/species/fragments.h
@@ -58,6 +58,8 @@ namespace molfunc{
             vector<Fragment> fragments;
 
             Fragment fragment(const string& name);
+
+            vector<vector<Fragment>> fragments_n_repeats(unsigned long n);
     };
 
 

--- a/molfunc/include/species/species.h
+++ b/molfunc/include/species/species.h
@@ -36,7 +36,10 @@ namespace molfunc{
             vector<unsigned long> masked_atom_idxs();
 
             void print_xyz_file(const string& filename);
+            void append_xyz_file(const string& filename);
 
+    private:
+        void print_xyz_file(const string& filename, bool append);
     };
 }
 

--- a/molfunc/molecules.py
+++ b/molfunc/molecules.py
@@ -1,7 +1,8 @@
 from typing import Sequence, Optional
 from molfunc.fragments import _frag_smiles_to_xyz_filenames
-from molfunc_ext import (print_combined_from_names,
-                         print_combined_from_xyz_filenames)
+from molfunc_ext import (c_print_combined_from_names,
+                         c_print_combined_from_xyz_filenames,
+                         c_print_all_combined_molecules)
 
 
 def print_combined_molecule(core_xyz_filename:  str,
@@ -37,9 +38,7 @@ def print_combined_molecule(core_xyz_filename:  str,
         name (str): Name of the molecule, thus generated .xyz file. e.g. ethane
                     -> ethane.xyz
     """
-    if not core_xyz_filename.endswith('.xyz'):
-        raise ValueError('Core .xyz filename must end with ".xyz". '
-                         f'Had: {core_xyz_filename}')
+    _validate_xyz_filename(core_xyz_filename)
 
     if all(f is None for f in (frag_names, frag_smiles, frag_xyz_filenames)):
         raise ValueError('Combination requires at least some fragments!')
@@ -51,25 +50,70 @@ def print_combined_molecule(core_xyz_filename:  str,
         raise ValueError('Cannot have fragment specified using structures and '
                          'names. Ordering may be ambiguous.')
 
-    # Convert the atom indexes from 1-> indexing to 0-> indexing
-    for i, atom_idx in enumerate(atoms_to_del):
-        if atom_idx <= 0:
-            raise ValueError(f'Cannot have an atom index of {atom_idx}, '
-                             f'must be indexed from 1')
-        atoms_to_del[i] -= 1
+    _decrement_atom_indices(atom_indices=atoms_to_del)
 
     # Cython passing strings python-> C requires encoding
     filename = bytes(f'{name}.xyz', 'utf-8')
     core_xyz_filename = bytes(core_xyz_filename, 'utf-8')
 
     if frag_names is not None:
-        print_combined_from_names(filename,
-                                  core_xyz_filename,
-                                  atoms_to_del,
-                                  [bytes(name, encoding='utf-8') for name in frag_names])
+        c_print_combined_from_names(filename,
+                                    core_xyz_filename,
+                                    atoms_to_del,
+                                    [bytes(name, encoding='utf-8') for name in frag_names])
     else:
-        print_combined_from_xyz_filenames(filename,
-                                          core_xyz_filename,
-                                          atoms_to_del,
-                                          [bytes(fn, encoding='utf-8') for fn in frag_xyz_filenames])
+        c_print_combined_from_xyz_filenames(filename,
+                                            core_xyz_filename,
+                                            atoms_to_del,
+                                            [bytes(fn, encoding='utf-8') for fn in frag_xyz_filenames])
+    return None
+
+
+def print_all_combined_molecules(core_xyz_filename: str,
+                                 atoms_to_del:      Sequence[int],
+                                 name:              str = 'combined_molecule'):
+    """
+    For a core given as a .xyz file generate all possible combinations of
+    fragments defined in the library. Will generate N^m structures in the
+    same .xyz file, where N is the number of fragments in the library and
+    m is the number of atoms to delete
+
+    ---------------------------------------------------------------------------
+    Arguments:
+
+        core_xyz_filename (str): .xyz filename of the core
+
+        atoms_to_del (sequence(int)): Atoms to delete & exchange for fragments
+                                      in the core. Indexed from 1
+
+        name (str): Name of the molecule, thus generated .xyz file. e.g. ethane
+                    -> ethane.xyz
+    """
+    _validate_xyz_filename(core_xyz_filename)
+    _decrement_atom_indices(atom_indices=atoms_to_del)
+
+    c_print_all_combined_molecules(bytes(f'{name}.xyz', 'utf-8'),
+                                   bytes(core_xyz_filename, 'utf-8'),
+                                   atoms_to_del)
+    return None
+
+
+def _validate_xyz_filename(xyz_filename: str):
+    """Validate a .xyz filename"""
+
+    if not xyz_filename.endswith('.xyz'):
+        raise ValueError('Core .xyz filename must end with ".xyz". '
+                         f'Had: {xyz_filename}')
+
+    return None
+
+
+def _decrement_atom_indices(atom_indices):
+
+    for i, atom_idx in enumerate(atom_indices):
+        if atom_idx <= 0:
+            raise ValueError(f'Cannot have an atom index of {atom_idx}, '
+                             f'must be indexed from 1')
+        atom_indices[i] -= 1
+
     return None

--- a/molfunc/molfunc.py
+++ b/molfunc/molfunc.py
@@ -1,5 +1,5 @@
 import argparse
-from molfunc.molecules import print_combined_molecule
+from molfunc.molecules import print_combined_molecule, print_all_combined_molecules
 
 
 def get_args():
@@ -19,6 +19,12 @@ def get_args():
                         type=str,
                         help='<Required> List of atom ids to swap for '
                              'fragments. e.g. 1 2')
+
+    parser.add_argument('--all',
+                        action='store_true',
+                        default=False,
+                        help='Attempt to build all combinations of '
+                             'fragments for a defined core')
 
     parser.add_argument('-s', '--fragment_smiles',
                         action='store',
@@ -50,8 +56,14 @@ def main():
     if args.name is None:
         args.name = args.xyz_filename.replace('.xyz', '_mod')
 
-    print_combined_molecule(core_xyz_filename=args.xyz_filename,
-                            atoms_to_del=[int(i) for i in args.atom_ids],
-                            frag_smiles=args.fragment_smiles,
-                            frag_names=args.fragment_names,
-                            name=args.name)
+    if args.all:
+        print_all_combined_molecules(core_xyz_filename=args.xyz_filename,
+                                     atoms_to_del=[int(i) for i in args.atom_ids],
+                                     name=args.name)
+
+    else:
+        print_combined_molecule(core_xyz_filename=args.xyz_filename,
+                                atoms_to_del=[int(i) for i in args.atom_ids],
+                                frag_smiles=args.fragment_smiles,
+                                frag_names=args.fragment_names,
+                                name=args.name)

--- a/molfunc/molfunc_ext.pyx
+++ b/molfunc/molfunc_ext.pyx
@@ -6,6 +6,10 @@ from libcpp.vector cimport vector
 
 cdef extern from "include/species/combined.h" namespace "molfunc":
 
+    void print_all_combined_molecules(string& xyz_filename,
+                                      string& core_xyz_filename,
+                                      vector[unsigned int]& atom_idxs_to_del) except +
+
     void print_combined_molecule_from_names(string& xyz_filename,
                                             string& core_xyz_filename,
                                             vector[unsigned int]& atom_idxs_to_del,
@@ -18,8 +22,11 @@ cdef extern from "include/species/combined.h" namespace "molfunc":
                                                     vector[string]& frag_xyz_filenames) except +
 
 
-def print_combined_from_names(string& xyz_filename, string& core_xyz_filename, vector[unsigned int]& atom_idxs_to_del, vector[string]& frag_names):
+def c_print_all_combined_molecules(string& xyz_filename, string& core_xyz_filename, vector[unsigned int]& atom_idxs_to_del):
+    print_all_combined_molecules(xyz_filename, core_xyz_filename, atom_idxs_to_del)
+
+def c_print_combined_from_names(string& xyz_filename, string& core_xyz_filename, vector[unsigned int]& atom_idxs_to_del, vector[string]& frag_names):
     print_combined_molecule_from_names(xyz_filename, core_xyz_filename, atom_idxs_to_del, frag_names)
 
-def print_combined_from_xyz_filenames(string& xyz_filename, string& core_xyz_filename, vector[unsigned int]& atom_idxs_to_del, vector[string]& frag_xyz_filenames):
+def c_print_combined_from_xyz_filenames(string& xyz_filename, string& core_xyz_filename, vector[unsigned int]& atom_idxs_to_del, vector[string]& frag_xyz_filenames):
     print_combined_molecule_from_xyz_filenames(xyz_filename, core_xyz_filename, atom_idxs_to_del, frag_xyz_filenames)

--- a/molfunc/src/species/combined.cpp
+++ b/molfunc/src/species/combined.cpp
@@ -34,9 +34,9 @@ namespace molfunc{
 
         unsigned long n_del_atoms = atom_idxs_to_del.size();
 
-        for (auto &fragments: FragmentLib::fragments_product(n_del_atoms)){
-            CombinedMolecule(core, fragments).to_molecule().appendxyz_file(xyz_filename);
-        }
+        //for (auto &fragments: FragmentLib::fragments_product(n_del_atoms)){
+        //    CombinedMolecule(core, fragments).to_molecule().append_xyz_file(xyz_filename);
+        //}
 
     }
 

--- a/molfunc/src/species/combined.cpp
+++ b/molfunc/src/species/combined.cpp
@@ -11,6 +11,35 @@ using namespace std;
 
 namespace molfunc{
 
+    void print_all_combined_molecules(const string& xyz_filename,
+                                      const string& core_xyz_filename,
+                                      const vector<unsigned int>& atom_idxs_to_del){
+        /******************************************************************
+         * Generate all possible combinations of a combined molecule
+         * based on the core and the current fragment library e.g.
+         * for a single atom to delete then generate
+         * N = FragmentLib::instance().size() number of combined molecules,
+         * for m atom to delete then will generate N^m structures.
+         *
+         *
+         *  xyz_filename: Name of the generated .xyz file
+         *
+         *  core_xyz_filename:
+         *
+         *  atom_idxs_to_del: Atom indexes to delete
+         ****************************************************************/
+
+        auto core = CoreMolecule(core_xyz_filename,
+                                 atom_idxs_to_del);
+
+        unsigned long n_del_atoms = atom_idxs_to_del.size();
+
+        for (auto &fragments: FragmentLib::fragments_product(n_del_atoms)){
+            CombinedMolecule(core, fragments).to_molecule().appendxyz_file(xyz_filename);
+        }
+
+    }
+
     void print_combined_molecule_from_names(const string& xyz_filename,
                                             const string& core_xyz_filename,
                                             const vector<unsigned int>& atom_idxs_to_del,

--- a/molfunc/src/species/combined.cpp
+++ b/molfunc/src/species/combined.cpp
@@ -33,11 +33,12 @@ namespace molfunc{
                                  atom_idxs_to_del);
 
         unsigned long n_del_atoms = atom_idxs_to_del.size();
+        auto fragments_vector = FragmentLib::instance().fragments_n_repeats(n_del_atoms);
 
-        //for (auto &fragments: FragmentLib::fragments_product(n_del_atoms)){
-        //    CombinedMolecule(core, fragments).to_molecule().append_xyz_file(xyz_filename);
-        //}
-
+        for (auto &fragments: fragments_vector){
+            auto mol = CombinedMolecule(core, fragments).to_molecule();
+            mol.append_xyz_file(xyz_filename);
+        }
     }
 
     void print_combined_molecule_from_names(const string& xyz_filename,

--- a/molfunc/src/species/combined.cpp
+++ b/molfunc/src/species/combined.cpp
@@ -29,8 +29,7 @@ namespace molfunc{
          *  atom_idxs_to_del: Atom indexes to delete
          ****************************************************************/
 
-        auto core = CoreMolecule(core_xyz_filename,
-                                 atom_idxs_to_del);
+        auto core = CoreMolecule(core_xyz_filename, atom_idxs_to_del);
 
         unsigned long n_del_atoms = atom_idxs_to_del.size();
         auto fragments_vector = FragmentLib::instance().fragments_n_repeats(n_del_atoms);

--- a/molfunc/src/species/fragments.cpp
+++ b/molfunc/src/species/fragments.cpp
@@ -154,15 +154,19 @@ namespace molfunc{
     }
 
     vector<vector<Fragment>> FragmentLib::fragments_n_repeats(unsigned long n){
-        /*********************************************************
-         * Generate a
+        /******************************************************************
+         * Generate a list (vector) of fragments with a specific
+         * number of repeats of all fragments in the library.
+         * This function is an implementation of a cartesian product
+         * from itertools in Python (https://docs.python.org/3/library/itertools.html)
+         * returns (N^n, n) matrix, where N fragments exist in the library.
          *
          * Arguments:
          *      n (str): Number of repeats to perform
          *
          * Raises:
          *      (runtime_error):
-         ********************************************************/
+         *****************************************************************/
 
         auto n_to_generate = (int)pow(FragmentLib::instance().fragments.size(), n);
 
@@ -175,7 +179,7 @@ namespace molfunc{
         pools.reserve(n);
 
         for (unsigned long i = 0; i < n; i++){
-            auto p = fragments;
+            auto p = fragments;  // Copy of the fragments
             pools.push_back(p);
         }
 

--- a/molfunc/src/species/fragments.cpp
+++ b/molfunc/src/species/fragments.cpp
@@ -174,7 +174,7 @@ namespace molfunc{
         vector<vector<Fragment>> pools = {};
         pools.reserve(n);
 
-        for (auto i = 0; i < n; i++){
+        for (unsigned long i = 0; i < n; i++){
             auto p = fragments;
             pools.push_back(p);
         }

--- a/molfunc/src/species/fragments.cpp
+++ b/molfunc/src/species/fragments.cpp
@@ -151,8 +151,58 @@ namespace molfunc{
         throw domain_error("Failed to find a fragment with an alias "+
                            name+" in the library");
     }
-}
 
+    vector<vector<Fragment>> FragmentLib::fragments_n_repeats(unsigned long n){
+        /*********************************************************
+         * Generate a
+         *
+         * Arguments:
+         *      n (str): Number of repeats to perform
+         *
+         * Raises:
+         *      (runtime_error):
+         ********************************************************/
+
+        auto n_to_generate = pow(FragmentLib::instance().fragments.size(), n);
+
+        if (n_to_generate > 1000){
+            throw runtime_error("Tried to generated "+to_string(n_to_generate)+
+                                " fragment combinations, likely unwanted");
+        }
+
+        vector<vector<Fragment>> pools = {};
+        pools.reserve(n);
+
+        for (auto i = 0; i < n; i++){
+            auto p = fragments;
+            pools.push_back(p);
+        }
+
+        vector<vector<Fragment>> result = {{}};
+
+        for (auto &pool : pools) {
+
+            if (result.empty()){
+                result.push_back(fragments);
+                continue;
+            }
+
+            vector<vector<Fragment>> tmp = {};
+            for (auto y: pool) {
+                for (auto x: result) {     // Requires copy?!
+                    x.push_back(y);
+                    tmp.push_back(x);
+                }
+            }
+            result = tmp;
+        }
+
+        return result;
+    }
+}
+/* -----------------------------------------------
+ Below data is automatically generated
+ -----------------------------------------------*/
 
 namespace molfunc{
      FragmentLib::FragmentLib(){

--- a/molfunc/src/species/fragments.cpp
+++ b/molfunc/src/species/fragments.cpp
@@ -164,11 +164,11 @@ namespace molfunc{
          *      (runtime_error):
          ********************************************************/
 
-        auto n_to_generate = pow(FragmentLib::instance().fragments.size(), n);
+        auto n_to_generate = (int)pow(FragmentLib::instance().fragments.size(), n);
 
         if (n_to_generate > 1000){
             throw runtime_error("Tried to generated "+to_string(n_to_generate)+
-                                " fragment combinations, likely unwanted");
+                                " fragment combinations, unsupported. Must be <1000");
         }
 
         vector<vector<Fragment>> pools = {};

--- a/molfunc/src/species/fragments.cpp
+++ b/molfunc/src/species/fragments.cpp
@@ -1,5 +1,6 @@
 #include "iostream"
-#include <algorithm>
+#include "algorithm"
+#include "math.h"
 #include "species/fragments.h"
 #include "utils.h"
 

--- a/molfunc/src/species/species.cpp
+++ b/molfunc/src/species/species.cpp
@@ -1,10 +1,9 @@
 #include "species/species.h"
-#include <fstream>
+#include "fstream"
 #include "string"
-#include <iomanip>
+#include "iomanip"
 #include "cmath"
 #include "memory"
-
 #include "iostream"
 
 
@@ -101,7 +100,8 @@ namespace molfunc{
         return (coordinates[j] - coordinates[i]) / l;
     }
 
-    void Species::print_xyz_file(const string& filename){
+    void Species::print_xyz_file(const string& filename,
+                                 bool append){
         /*********************************************************
          * Generate a standard .xyz file for a molecule
          *
@@ -113,7 +113,9 @@ namespace molfunc{
             throw runtime_error("Could not print a .xyz file- had no atoms");
         }
 
-        ofstream xyz_file (filename);
+        ofstream xyz_file;
+        if (append) xyz_file.open(filename, ios_base::app);
+        else xyz_file.open(filename);
 
         if (xyz_file.is_open()){
 
@@ -139,6 +141,16 @@ namespace molfunc{
         }
 
         else throw runtime_error("Cannot open "+filename);
+    }
+
+    void Species::print_xyz_file(const string& filename){
+        // Print the .xyz file of this molecule, will override
+        print_xyz_file(filename, false);
+    }
+
+    void Species::append_xyz_file(const string &filename) {
+        // Append to a (possibly) existing .xyz file
+        print_xyz_file(filename, true);
     }
 
     void Species::rotate(const RotationMatrix &R) {

--- a/molfunc/tests/test_combination.cpp
+++ b/molfunc/tests/test_combination.cpp
@@ -386,6 +386,18 @@ TEST_CASE("Test methane + Me, F"){
 
 
 TEST_CASE("Test methane + all construction"){
-    //
+    // Ensure that a series of fragments can be added
+    // and the structures appended to the same .xyz file
 
+    print_core_xyz();
+    print_all_combined_molecules("tmp.xyz",
+                                 "core.xyz",
+                                 {1});
+
+    ifstream xyz_file("tmp.xyz");
+    auto n_lines = count(std::istreambuf_iterator<char>(xyz_file),
+                         istreambuf_iterator<char>(), '\n');
+
+    // Should be plenty of structures!
+    REQUIRE(n_lines > 100);
 }

--- a/molfunc/tests/test_combination.cpp
+++ b/molfunc/tests/test_combination.cpp
@@ -82,7 +82,6 @@ CoreMolecule core_pr3(){
 }
 
 
-
 CoreMolecule benzene_core_mol(){
 
     ofstream xyz_file ("core.xyz");
@@ -385,3 +384,8 @@ TEST_CASE("Test methane + Me, F"){
     }
 }
 
+
+TEST_CASE("Test methane + all construction"){
+    //
+
+}

--- a/molfunc/tests/test_fragments.cpp
+++ b/molfunc/tests/test_fragments.cpp
@@ -116,7 +116,7 @@ TEST_CASE("Test repeated fragment combinations"){
     /* Should be able to generate all possible
      of fragments with a defined number of repeats
      e.g a fragment library of size 2 should generate:
-     n = 1   --> [[frag1, frag2]]
+     n = 1   --> [[frag1], [frag2]]
      n = 2   --> [[frag1, frag1],
                   [frag1, frag2],
                   [frag2, frag1],

--- a/molfunc/tests/test_fragments.cpp
+++ b/molfunc/tests/test_fragments.cpp
@@ -110,3 +110,30 @@ TEST_CASE("Test coordinate reset"){
     fragment.reset_coordinates();
     REQUIRE(utils::is_close(fragment.coordinates[0].x(), 0.92450));
 }
+
+
+TEST_CASE("Test repeated fragment combinations"){
+    /* Should be able to generate all possible
+     of fragments with a defined number of repeats
+     e.g a fragment library of size 2 should generate:
+     n = 1   --> [[frag1, frag2]]
+     n = 2   --> [[frag1, frag1],
+                  [frag1, frag2],
+                  [frag2, frag1],
+                  [frag2, frag2]]
+    */
+
+    auto n_fragments = FragmentLib::instance().fragments.size();
+
+    auto vec_fragments = FragmentLib::instance().fragments_n_repeats(1);
+    REQUIRE(vec_fragments.size() == n_fragments);
+    REQUIRE(vec_fragments[0].size() == 1);
+
+    vec_fragments = FragmentLib::instance().fragments_n_repeats(2);
+
+    REQUIRE(vec_fragments.size() == n_fragments*n_fragments);
+
+    // Don't generate > 24 million combinations..
+    REQUIRE_THROWS(FragmentLib::instance().fragments_n_repeats(5));
+}
+

--- a/molfunc/tests/test_molecule.cpp
+++ b/molfunc/tests/test_molecule.cpp
@@ -189,3 +189,19 @@ TEST_CASE("Test indexing with to without masked atoms"){
     REQUIRE(mol.no_masked_idx(0) == 0);
     REQUIRE(mol.no_masked_idx(2) == 1);
 }
+
+
+TEST_CASE("Test appending to a xyz file"){
+
+    auto mol = methane_molecule();
+
+    mol.append_xyz_file("tmp.xyz");
+    mol.append_xyz_file("tmp.xyz");
+
+    ifstream inFile("tmp.xyz");
+    auto n_lines = count(std::istreambuf_iterator<char>(inFile),
+                    istreambuf_iterator<char>(), '\n');
+
+    // Appended file needs to have at least 2, 5 line sets of coordinates in
+    REQUIRE(n_lines > 10);
+}

--- a/molfunc/tests/test_molecule.cpp
+++ b/molfunc/tests/test_molecule.cpp
@@ -198,10 +198,11 @@ TEST_CASE("Test appending to a xyz file"){
     mol.append_xyz_file("tmp.xyz");
     mol.append_xyz_file("tmp.xyz");
 
-    ifstream inFile("tmp.xyz");
-    auto n_lines = count(std::istreambuf_iterator<char>(inFile),
+    ifstream xyz_file("tmp.xyz");
+    auto n_lines = count(std::istreambuf_iterator<char>(xyz_file),
                     istreambuf_iterator<char>(), '\n');
 
     // Appended file needs to have at least 2, 5 line sets of coordinates in
     REQUIRE(n_lines > 10);
+    remove("tmp.xyz");
 }

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ def _post_install():
          cwd=here)
 
 
-class install(_install):
+class Install(_install):
     def run(self):
         self.execute(_post_install,
                      args=(),
@@ -29,18 +29,19 @@ extensions = [Extension('molfunc_ext',
                         include_dirs=['molfunc/include'],
                         language='c++',
                         extra_compile_args=["-std=c++17", "-Wno-missing-braces", "-O3"],
-                        extra_link_args=["-std=c++17"]
-                        )]
+                        extra_link_args=["-std=c++17"])
+              ]
 
 setup(name='molfunc',
-      version='2.0.0a0',
+      version='2.0.0b0',
       packages=['molfunc'],
       license='MIT',
-      package_data={"molfunc": ["include/*.h", "src/*.cpp", "include/species/*.h", "src/species/*.cpp", "scripts/*.py", "*.pyx"]},
+      package_data={"molfunc": ["include/*.h", "src/*.cpp", "include/species/*.h",
+                                "src/species/*.cpp", "scripts/*.py", "*.pyx"]},
       build_requires=["Cython"],
       author='Tom Young',
       url='https://github.com/duartegroup/molfunc',
-      cmdclass={'install': install},
+      cmdclass={'install': Install},
       entry_points={'console_scripts': ['molfunc = molfunc.molfunc:main']},
       ext_modules=cythonize(extensions, language_level="3"),
       author_email='tom.young@chem.ox.ac.uk',

--- a/tests/all_test.py
+++ b/tests/all_test.py
@@ -5,8 +5,10 @@ import numpy as np
 from subprocess import Popen
 from scipy.spatial import distance_matrix
 from autode import Molecule
-from molfunc import print_combined_molecule, fragment_names
 from molfunc.molfunc import main
+from molfunc import (print_combined_molecule,
+                     print_all_combined_molecules,
+                     fragment_names)
 
 
 here = os.path.dirname(os.path.abspath(__file__))
@@ -47,6 +49,16 @@ def test_cli():
 def test_main():
     # For the example benzene -> toluene modification call the main molfunc
     sys.argv[1:] = [xyz_path, '-a', '7', '-f', 'Me']
+    main()
+
+    toluene_path = os.path.join(here, 'data', 'benzene_mod.xyz')
+    assert os.path.exists(toluene_path)
+    os.remove(toluene_path)
+
+
+def test_main_all():
+    # For the example benzene -> toluene modification call the main molfunc
+    sys.argv[1:] = [xyz_path, '-a', '7', '--all']
     main()
 
     toluene_path = os.path.join(here, 'data', 'benzene_mod.xyz')
@@ -131,3 +143,32 @@ def test_not_ok_core():
         print_combined_molecule(core_xyz_filename=os.path.join(here, 'data', 'benzene.xyz'),
                                 atoms_to_del=[0],
                                 frag_names=['Me'])
+
+
+def test_all_combination():
+    """Test all possible combinations can be generated reasonably"""
+
+    ph3_filepath = os.path.join(here, 'data', 'PH3.xyz')
+    print_all_combined_molecules(ph3_filepath,
+                                 atoms_to_del=[2],
+                                 name='tmp')
+
+    assert os.path.exists('tmp.xyz')
+
+    xyz_lines = []
+    for line in open('tmp.xyz', 'r'):
+
+        xyz_lines.append(line)
+
+        if len(line.split()) != 1 or len(xyz_lines) <= 1:
+            continue
+
+        with open('single_tmp.xyz', 'w') as single_xyz_file:
+            for _line in xyz_lines[:-1]:
+                print(_line, file=single_xyz_file, end='')
+
+        assert _xyz_file_is_reasonable('single_tmp.xyz')
+        xyz_lines = xyz_lines[-1:]
+
+    os.remove('tmp.xyz')
+    os.remove('single_tmp.xyz')


### PR DESCRIPTION
Enable functionalsiing a molecule with all possible combinations using the fragment library. Suggested CLI

```bash
molfunc tmp.xyz -a 2 --all
```

and Python API

```python
from molfunc import print_combined_molecule

print_all_combined_molecules(core_xyz_filename='methane.xyz', 
                             atoms_to_del=[1],
                             frag_names='all',
                             name='combined')
```

Should generate N^M structures, all saved to the same .xyz file.

***

- [x] Top-level C++ function
- [x] Repeated fragment list generation in all permutations
- [x] Cython wrap
- [x] Add flag to argparse
- [x] Bump version in README

